### PR TITLE
feat: implement optional compression based on threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ and pass them as the node list in the multi-node function.
         port = 65535
       4. node_name = `emqx60166@127.0.0.1`:
         invalid and gen_rpc cannot get started
+- `compress`: A number (default = 0) from 0 to 9 to define level of compression.
+
+- `compression_threshold`: The minimum amount of bytes (default = 1024) needed to be worth compressing the TCP message sent.
 
 - `tcp_server_port`: The plain TCP port `gen_rpc` will use for incoming connections or `false` if you
   do not want plain TCP enabled. Only takes effect when `port_discovery` = `manual`.

--- a/src/gen_rpc.app.src
+++ b/src/gen_rpc.app.src
@@ -88,7 +88,12 @@
         %% NOTE: this option has no effect unless 'socket_ip' is an IPv6 interface.
         {ipv6_only, false},
         %% ActiveN option for RPC acceptor socket
-        {acceptor_socket_active_n, 100}
+        {acceptor_socket_active_n, 100},
+        %% Compression options
+        %% 0 means no compression, 9 max compression level
+        {compress, 0},
+        %% Threshold for compression to kick in
+        {compression_threshold, 1024}
     ]},
     {modules, []}]
 }.

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -274,7 +274,7 @@ call_worker(CallType, M, F, A, Caller, Socket, Driver, DriverMod) ->
 reply_call_result({CallType,_Caller,_Res} = Payload, Socket, Driver, DriverMod) ->
     ?log(debug, "message=call_reply event=call_reply_received driver=~s socket=\"~s\" type=~s",
          [Driver, gen_rpc_helper:socket_to_string(Socket), CallType]),
-    case DriverMod:send(Socket, erlang:term_to_iovec(Payload)) of
+    case DriverMod:send(Socket, gen_rpc_helper:term_to_iovec(Payload)) of
         ok ->
             ?log(debug, "message=call_reply event=call_reply_sent driver=~s socket=\"~s\"", [Driver, gen_rpc_helper:socket_to_string(Socket)]);
         {error, Reason} ->

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -280,7 +280,7 @@ init({Node}) ->
 
 %% This is the actual CALL handler
 handle_call({{call,_M,_F,_A} = PacketTuple, SendTimeout}, Caller, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
-    Packet = erlang:term_to_iovec({PacketTuple, Caller}),
+    Packet = gen_rpc_helper:term_to_iovec({PacketTuple, Caller}),
     ?log(debug, "message=call event=constructing_call_term driver=~s socket=\"~s\" caller=\"~p\"",
          [Driver, gen_rpc_helper:socket_to_string(Socket), Caller]),
     ok = DriverMod:set_send_timeout(Socket, SendTimeout),
@@ -305,7 +305,7 @@ handle_call(Msg, _Caller, #state{socket=Socket, driver=Driver} = State) ->
 
 %% This is the actual ASYNC CALL handler
 handle_cast({{async_call,_M,_F,_A} = PacketTuple, Caller, Ref}, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
-    Packet = erlang:term_to_iovec({PacketTuple, {Caller,Ref}}),
+    Packet = gen_rpc_helper:term_to_iovec({PacketTuple, {Caller,Ref}}),
     ?log(debug, "message=async_call event=constructing_async_call_term socket=\"~s\" worker_pid=\"~p\" async_call_ref=\"~p\"",
          [gen_rpc_helper:socket_to_string(Socket), Caller, Ref]),
     ok = DriverMod:set_send_timeout(Socket, undefined),
@@ -427,7 +427,7 @@ send_cast(PacketTuple, #state{socket=Socket, driver=Driver, driver_mod=DriverMod
                               , driver  => Driver
                               , socket  => gen_rpc_helper:socket_to_string(Socket)
                               }),
-    Packet = erlang:term_to_iovec(PacketTuple),
+    Packet = gen_rpc_helper:term_to_iovec(PacketTuple),
     ok = DriverMod:set_send_timeout(Socket, SendTimeout),
     case DriverMod:send_async(Socket, Packet) of
         {error, Reason} ->

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -56,7 +56,7 @@ term_to_iovec(Term) ->
   {ok, Compress} = application:get_env(?APP, compress),
   do_term_to_iovec(Term, Compress).
 
-do_term_to_iovec(Term, Compress) when is_integer(Compress), Compress > 0 ->
+do_term_to_iovec(Term, Compress) when is_integer(Compress), Compress >= 1, Compress =< 9 ->
     Size = erlang:external_size(Term),
     {ok, CompressionThreshold} = application:get_env(?APP, compression_threshold),
     case Size > CompressionThreshold of

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -17,6 +17,8 @@
 %%% Include helpful guard macros
 -include("types.hrl").
 
+-include_lib("snabbkaffe/include/trace.hrl").
+
 -define(DEFAULT_LISTEN_PORT, 5370).
 -define(MAX_PORT_LIMIT, 60000).
 
@@ -41,11 +43,35 @@
          get_control_receive_timeout/0,
          get_inactivity_timeout/1,
          get_async_call_inactivity_timeout/0,
-         get_listen_ip_config/0]).
+         get_listen_ip_config/0,
+         term_to_iovec/1]).
 
 %%% ===================================================
 %%% Public API
 %%% ===================================================
+
+%% term_to_iovec/1 wrapper to conditionally compress based on threshold
+-spec term_to_iovec(term()) -> ext_iovec.
+term_to_iovec(Term) ->
+  {ok, Compress} = application:get_env(?APP, compress),
+  do_term_to_iovec(Term, Compress).
+
+do_term_to_iovec(Term, Compress) when is_integer(Compress), Compress > 0 ->
+    Size = erlang:external_size(Term),
+    {ok, CompressionThreshold} = application:get_env(?APP, compression_threshold),
+    case Size > CompressionThreshold of
+        true  ->
+            Data = erlang:term_to_iovec(Term, [{compressed, Compress}]),
+            ?tp_ignore_side_effects_in_prod(gen_rpc_compress_payload, #{ threshold => CompressionThreshold,
+                                                                         original_size => Size,
+                                                                         compressed_size => iolist_size(Data)
+                                                                       }),
+            Data;
+        false -> erlang:term_to_iovec(Term)
+    end;
+do_term_to_iovec(Term, _) ->
+    erlang:term_to_iovec(Term).
+
 %% Return the connected peer's IP
 -spec peer_to_string({inet:ip_address(), inet:port_number()} | inet:ip_address()) -> string().
 peer_to_string({Ip, Port}) when tuple_size(Ip) =:= 4 ->


### PR DESCRIPTION
Two new options:

- `compress`: A number (default = 0) from 0 to 9 to define level of compression.
- `compression_threshold`: The minimum amount of bytes (default = 1024) needed to be worth compressing the TCP message sent.

See https://www.erlang.org/doc/apps/erts/erlang.html#term_to_binary/2 for more information on how compression works.