### PR TITLE
fix: set fullsweep_after=20 to gen_rpc_client and gen_rpc_acceptor

### DIFF
--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -71,6 +71,7 @@ set_socket(Pid, Socket) when is_pid(Pid) ->
 %%% ===================================================
 init({Driver, Peer}) ->
     ok = gen_rpc_helper:set_optimal_process_flags(),
+    _ = erlang:process_flag(fullsweep_after, 20),
     {Control, ControlList} = gen_rpc_helper:get_rpc_module_control(),
     {DriverMod, _DriverPort, DriverClosed, DriverError} = gen_rpc_helper:get_server_driver_options(Driver),
     ?log(info, "event=start driver=~s peer=\"~s\"", [Driver, gen_rpc_helper:peer_to_string(Peer)]),

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -237,6 +237,7 @@ init({{Node,_Key}}) ->
 
 init({Node}) ->
     ok = gen_rpc_helper:set_optimal_process_flags(),
+    _ = erlang:process_flag(fullsweep_after, 20),
     case gen_rpc_helper:get_client_config_per_node(Node) of
         {error, Reason} ->
             ?log(error, "event=external_source_error action=falling_back_to_local reason=\"~s\"", [Reason]),


### PR DESCRIPTION
These two processes receive tons of messages, process them and discard them.

From the Erlang docs:

    A few cases when it can be useful to change fullsweep_after:

    * If binaries that are no longer used are to be thrown away as soon as possible. (Set Number to zero.)
    * A process that mostly have short-lived data is fullsweeped seldom or never, that is, the old heap contains mostly garbage. To ensure a fullsweep occasionally, set Number to a suitable value, such as 10 or 20.
    * In embedded systems with a limited amount of RAM and no virtual memory, you might want to preserve memory by setting Number to zero. (The value can be set globally, see erlang:system_flag/2.)
